### PR TITLE
libqqwing: add get_version()

### DIFF
--- a/cpp/qqwing.cpp
+++ b/cpp/qqwing.cpp
@@ -29,6 +29,10 @@
 
 namespace qqwing {
 
+	string getVersion(){
+		return VERSION;
+	}
+
 	/**
 	 * While solving the puzzle, log steps taken in a log item.
 	 * This is useful for later printing out the solve history

--- a/cpp/qqwing.hpp
+++ b/cpp/qqwing.hpp
@@ -43,6 +43,11 @@
 		const int POSSIBILITY_SIZE = BOARD_SIZE*NUM_POSS;
 
 		/**
+		 * The version of QQwing, e.g. 1.2.3
+		 */
+		string getVersion();
+
+		/**
 		 * The board containing all the memory structures and
 		 * methods for solving or generating sudoku puzzles.
 		 */


### PR DESCRIPTION
This might well be my last pull request, at least for a while. We have a branch of GNOME Sudoku that uses qqwing to generate puzzles, and it works great! I also got final approval for GNOME to depend on qqwing. I will merge our qqwing branch as soon as you release a new version, since we need the getPuzzle() function I added a couple of days ago.

Anyway this request is not needed, but a nice-to-have: we'd like to display "Puzzles generated by QQwing 1.2.3" on our about dialog. (qqwing is such a major dependency, it deserves a little bit of advertisement, I think. :)
