### PR TITLE
Revert soname bump

### DIFF
--- a/build/configure.ac
+++ b/build/configure.ac
@@ -12,8 +12,8 @@ AC_CONFIG_HEADER([config.h])
 #   change to C+1:0:0
 # - If the interface is the same as the previous version, change to C:R+1:A
 QQWING_CURRENT=2
-QQWING_REVISION=0
-QQWING_AGE=1
+QQWING_REVISION=1
+QQWING_AGE=0
 
 AC_SUBST([QQWING_CURRENT])
 AC_SUBST([QQWING_REVISION])


### PR DESCRIPTION
This must have been a mistake, since the C++ library hasn't changed at all. Best to only increment age in tandem with current.

libtool versioning is silly and confusing, so I have a comment above those variables explaining one good strategy for maintaining it.

Only accept this pull request if you plan to do a fixup release right away (which I would recommend, to save trouble for distributions); otherwise, downstreams can just rebuild gnome-sudoku.
