### PR TITLE
Improved error in main.cpp. Improved code formatting.

### DIFF
--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -274,7 +274,7 @@ int main(int argc, char *argv[]){
 					havePuzzle = false;
 					done = true;
 				}
-				delete puzzle;
+				delete[] puzzle;
 			}
 
 			int solutions = 0;

--- a/src/cpp/qqwing.cpp
+++ b/src/cpp/qqwing.cpp
@@ -225,11 +225,11 @@ namespace qqwing {
 	string SudokuBoard::getDifficultyAsString(){
 		SudokuBoard::Difficulty difficulty = getDifficulty();
 		switch (difficulty){
-			case SudokuBoard::EXPERT: return "Expert"; break;
-			case SudokuBoard::INTERMEDIATE: return "Intermediate"; break;
-			case SudokuBoard::EASY: return "Easy"; break;
-			case SudokuBoard::SIMPLE: return "Simple"; break;
-			default: return "Unknown"; break;
+			case SudokuBoard::EXPERT: return "Expert"; 
+			case SudokuBoard::INTERMEDIATE: return "Intermediate"; 
+			case SudokuBoard::EASY: return "Easy";
+			case SudokuBoard::SIMPLE: return "Simple";
+			default: return "Unknown"; 
 		}
 	}
 
@@ -655,18 +655,18 @@ namespace qqwing {
 	}
 
 	bool SudokuBoard::singleSolveMove(int round){
-		if (onlyPossibilityForCell(round)) return true;
-		if (onlyValueInSection(round)) return true;
-		if (onlyValueInRow(round)) return true;
-		if (onlyValueInColumn(round)) return true;
-		if (handleNakedPairs(round)) return true;
-		if (pointingRowReduction(round)) return true;
-		if (pointingColumnReduction(round)) return true;
-		if (rowBoxReduction(round)) return true;
-		if (colBoxReduction(round)) return true;
-		if (hiddenPairInRow(round)) return true;
-		if (hiddenPairInColumn(round)) return true;
-		if (hiddenPairInSection(round)) return true;
+		if ( onlyPossibilityForCell(round) 
+			|| onlyValueInSection(round) 
+			|| onlyValueInRow(round)
+			|| onlyValueInColumn(round) 
+			|| handleNakedPairs(round)
+			|| pointingRowReduction(round)
+			|| pointingColumnReduction(round)
+			|| rowBoxReduction(round)
+			|| colBoxReduction(round)
+			|| hiddenPairInRow(round)
+			|| hiddenPairInColumn(round)
+			|| hiddenPairInSection(round) ) return true;
 		return false;
 	}
 


### PR DESCRIPTION
In main.cpp avoid mismatching allocation and deallocation of puzzle.
For arrays need to use delete[].

Applied rules:
- use prefix increment form (except situation where postfix needed)
- try to split very long lines
- add space after comma
- write \* near identifier
- avoid unneccessery brackets
